### PR TITLE
Enable runtime to build for Apple Silicon

### DIFF
--- a/Source/Slithin/Slithin.csproj
+++ b/Source/Slithin/Slithin.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon>Resources/Icon.ico</ApplicationIcon>
     <Version>1.0.10.0</Version>
-	<RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
+	<RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64;osx.12-arm64</RuntimeIdentifiers>
     <PackageDescription>A management application for your rM Tablet 1 and 2</PackageDescription>
     <Platforms>AnyCPU;x64;x86;ARM32;ARM64</Platforms>
     <LangVersion>10</LangVersion>


### PR DESCRIPTION
- adds osx.12-arm64 in runtime identifiers
- enables native builds for m1 machines using the arm64 .NET runtime